### PR TITLE
Persist county selections in querystring

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@testing-library/react": "^9.3.2",
     "@testing-library/user-event": "^7.1.2",
     "convert-csv-to-json": "^0.0.15",
+    "query-string": "^6.11.1",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-ga": "^2.7.0",


### PR DESCRIPTION
I wanted to be able to share a link that charted a specific set of counties rather than the default set. So, this change:

* Saves the counties you select to the querystring
* When the page is loaded, it parses the querystring, saves the selected counties to state, and updates the chart with your selection.

Admittedly, the querystring is a bit long and ugly. And there might be cleaner ways to parse and cache the data. 